### PR TITLE
Use wildcards in Gulp minify task.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,7 +38,7 @@ gulp.task('minify', function () {
 		.pipe(rename('main.min.css'))
 		.pipe(gulp.dest('./public/css'));
 
-	gulp.src(['./public/scripts/angular.js', './app/directives/materialRipple.js', './app/controllers/linkCtrlr.client.js', './app/controllers/commentCtrlr.client.js'])
+	gulp.src(['./public/scripts/angular.js', './app/directives/**/*.js', './app/controllers/**/*.client.js'])
 		.pipe(concat('site.js'))
 		.pipe(uglify({
 			mangle: false


### PR DESCRIPTION
I used `.app/controllers/**/*.client.js` and `.app/directives/**/*.js` so the task should search the sub directories as well if needed.

resolve #2
