### PR TITLE
Add config files for prod/dev settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
+config/local.env.js
 node_modules/
 public/lib/
 public/css/

--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var env = process.env.NODE_ENV || 'local';
+
+module.exports = require('./' + env + '.env');

--- a/config/local.env.sample.js
+++ b/config/local.env.sample.js
@@ -1,0 +1,16 @@
+'use strict';
+
+// Copy this file to ./local.env.js and modify as needed.
+
+// This file should not be tracked by git.
+// Local environmental settings, secrets, and api keys should be stored here.
+
+module.exports = {
+	env:	'development',
+
+	port:	9000,
+
+	mongo: {
+		uri:	'mongodb://localhost:27017/clementinejs'
+	}
+};

--- a/config/production.env.js
+++ b/config/production.env.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+	env:	process.env.NODE_ENV,
+
+	port:	process.env.PORT || 8080,
+
+	mongo: {
+		uri:	process.env.MONGOLAB_URI ||
+					process.env.MONGOHQ_URL ||
+					undefined
+	}
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,8 +11,8 @@ var gulp = require('gulp'),
 
 function restartTime () {
 	function checkTime(i) {
-        return (i < 10) ? '0' + i : i;
-    }
+		return (i < 10) ? '0' + i : i;
+	}
 	var today = new Date(),
 		hrs = checkTime(today.getHours()),
 		min = checkTime(today.getMinutes()),
@@ -53,21 +53,26 @@ gulp.task('minify', function () {
 
 gulp.task('dist', ['clean', 'minify'], function () {
 	gulp.src([
+		'config/**/*',
+		'!config/local.env.*'
+	], { base: 'config' })
+		.pipe(gulp.dest('dist/config'));
+	gulp.src([
 		'public/**/*',
 		'!public/{lib{,/**/*},scripts/angular.js}'
 	], { base: 'public' })
-	  .pipe(gulp.dest('dist/public'));
+		.pipe(gulp.dest('dist/public'));
 
 	gulp.src([
 		'app/**/*',
 		'!app/css{,/**/*}',
-	  '!app/controllers/**/*.client.js',
+		'!app/controllers/**/*.client.js',
 		'!app/directives{,/**/*}'
 	], { base: 'app' })
-	  .pipe(gulp.dest('dist/app'));
+		.pipe(gulp.dest('dist/app'));
 
 	gulp.src(['bower.json', 'package.json', 'server.js'])
-	  .pipe(gulp.dest('dist'));
+		.pipe(gulp.dest('dist'));
 });
 
 gulp.task('build', ['clean', 'minify', 'dist']);

--- a/server.js
+++ b/server.js
@@ -3,12 +3,13 @@
 //Initialize Dependencies
 var express = require('express'),
 	db = require('mongoose'),
-	bodyParser = require('body-parser');
+	bodyParser = require('body-parser'),
+	config = require('./config/index');
 
 var	app = express();
 
 //Database connection
-db.connect('mongodb://localhost:27017/clementinejs');
+db.connect(config.mongo.uri);
 
 //Initialize Middleware
 app.use(bodyParser.json());
@@ -26,7 +27,6 @@ app.use('/directives', express.static(__dirname + '/app/directives'));
 require('./app/routes/index.js')(app);
 
 //listen
-var port = 3000;
-app.listen(3000, function (req, res) {
-	console.log('Listening on port ' + port + '...');
+app.listen(config.port, function (req, res) {
+	console.log('Listening on port ' + config.port + '...');
 });


### PR DESCRIPTION
This change makes it so if the process.env.NODE_ENV is not set, the config falls back to a local.env.js config file. I added this file to the .gitignore and made a sample that is tracked. This makes deploying the `dist` folder pretty smooth. 

This change would make it so that the user must make a copy of `local.env.sample.js` to `local.env.js` before they can run the local server. I'm not sure if that or not including the `local.env.js` by default in the ignore file and having them add it if site or api secrets are added to the file is the way to go.
