### PR TITLE
Fix code block format in Simple Node Server section

### DIFF
--- a/tutorials/tutorial-beginner.md
+++ b/tutorials/tutorial-beginner.md
@@ -248,7 +248,7 @@ Within this file:
 
 ```html
 <!DOCTYPE html>
-	<html>
+<html>
 	<head>
 		<title>First Node App</title>
 	</head>


### PR DESCRIPTION
Unindented opening  `<html>` tag to match closing `</html>` tag in code block.

(Fixes #16) 
