### PR TITLE
docs(install): Added manualfork as installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ In order to use Clementine.js, you must have the following installed:
 
 ### Installation & Startup
 
-There are 2 ways to install Clementine.js:
+There are 3 ways to install Clementine.js:
 
 - Clone the GitHub Repository
+- Clone using Manualfork
 - Install via Yeoman Generator
 
 Both options are similar, and a matter of preference.
@@ -44,7 +45,20 @@ $ git clone https://github.com/johnstonbl01/clementinejs.git your-project
 
 This will install the Clementine.js components into the `your-project` directory.
 
-**Option 2 - Yeoman Generator**
+**Option 2 - Clone using Manualfork**
+
+Manualfork is a tool that does 1:1 mirrors of Github repos. Click on the button below to begin cloning this repo.
+
+[![manualfork this repo](http://manualfork.therebelrobot.com/badge-large.svg)](http://manualfork.therebelrobot.com/?source=johnstonbl01/clementinejs)
+
+Alernatively, you can use the [manualfork cli tool](https://github.com/therebelrobot/node-manualfork) to clone it from the command line:
+
+```bash
+npm install -g manualfork
+manualfork johnstonbl01/clementinejs to USER/REPO -u USERNAME -t ACCESS_TOKEN
+```
+
+**Option 3 - Yeoman Generator**
 
 ```bash
 $ npm install -g generator-clementinejs


### PR DESCRIPTION
I recently developed/released a repo cloning tool called [manualfork](http://manualfork.therebelrobot.com/) which can greatly simplify the cloning process for this template. I've included the links to test it here if you want to try it out, I've already tested it myself with clementine and it seems to [do the trick pretty well](https://github.com/therebelbeta/clementinejs-test).

Let me know what you think.

http://manualfork.therebelrobot.com/?source=johnstonbl01/clementinejs
