### PR TITLE
updated ready function declaration and call

### DIFF
--- a/app/controllers/clickController.client.js
+++ b/app/controllers/clickController.client.js
@@ -7,16 +7,16 @@
    var clickNbr = document.querySelector('#click-nbr');
    var apiUrl = 'http://localhost:3000/api/clicks';
 
-   function ready (fn) {
+   function ready (fn, method, url, callback) {
       if (typeof fn !== 'function') {
          return;
       }
 
       if (document.readyState === 'complete') {
-         return fn();
+         return fn(method, url, callback);
       }
 
-      document.addEventListener('DOMContentLoaded', fn, false);
+      document.addEventListener('DOMContentLoaded', fn(method, url, callback), false);
    }
 
    function ajaxRequest (method, url, callback) {
@@ -37,7 +37,7 @@
       clickNbr.innerHTML = clicksObject.clicks;
    }
 
-   ready(ajaxRequest('GET', apiUrl, updateClickCount));
+   ready(ajaxRequest, 'GET', apiUrl, updateClickCount);
 
    addButton.addEventListener('click', function () {
 


### PR DESCRIPTION
Okay. I'm not sure exactly why this works the way it does and any clarification would be greatly appreciated. Here's what I noticed:

1. In the original code 'typeof fn' would always return 'undefined', yet the coded seemed to work as expected.
2. After a few hours playing around with it, I realized that the ajaxRequest function was triggering automatically from ready(ajaxRequest(...)); and have since read that if functions are used as parameters and include '()' that they are always called immediately.
3. So, to force ajaxRequest to wait until the ready function confirms the document is indeed ready, I changed out the parameters to pass through and then be applied once ready is confirmed.

What I really don't get is why a function passed as a parameter with '()' would return typeof undefined, but if you pass it without '()' than it returns typeof function?

Any ideas?